### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-sast-dast.yml
+++ b/.github/workflows/ci-sast-dast.yml
@@ -1,4 +1,6 @@
 name: CI with SAST and DAST
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/febry-setyawan/crud/security/code-scanning/17](https://github.com/febry-setyawan/crud/security/code-scanning/17)

To fix the issue, you should explicitly set the `permissions` key at the top level of the workflow file (`.github/workflows/ci-sast-dast.yml`). This will apply minimal permissions (e.g., `contents: read`) to all jobs unless a job explicitly overrides them. Since the jobs only check out code and upload artifacts (which do not require elevated repository privileges), `contents: read` suffices. The change should be made at the start of the file, directly after the `name:` line and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
